### PR TITLE
Update run_nuclear_feature_extraction.py

### DIFF
--- a/nmco/utils/run_nuclear_feature_extraction.py
+++ b/nmco/utils/run_nuclear_feature_extraction.py
@@ -60,7 +60,7 @@ def run_nuclear_chromatin_feat_ext(raw_image_path:str, labelled_image_path:str, 
     for i in tqdm(range(len(props))):
         all_features = all_features.append(
             pd.concat(
-                [pd.DataFrame([i + 1], columns=["label"]),
+                [pd.DataFrame([props[i].label], columns=["label"]),
                  BG.measure_global_morphometrics(props[i].image, 
                                                  angular_resolution = calliper_angular_resolution, 
                                                  measure_simple = measure_simple_geometry,


### PR DESCRIPTION
change from pd.DataFrame([i + 1], columns=["label"]) into pd.DataFrame([props[i].label], columns=["label"]). The reason is that, for some images I used, measure.regionprops doesn't include all the labels !!!